### PR TITLE
fpb --build failing due to a non-existent path specified

### DIFF
--- a/pre_build_hook
+++ b/pre_build_hook
@@ -10,4 +10,4 @@ DEB_REPO="${ROOT}"/repositories/ubuntu/
 
 wget -qO- "${REPO_PATH}" | \
     tar -C "${MODULES}" --strip-components=3 -zxvf - \
-    stackforge-fuel-library-a478b8c/deployment/puppet/{inifile,stdlib,pacemaker}
+    openstack-fuel-library-a478b8c/deployment/puppet/{inifile,stdlib,pacemaker}


### PR DESCRIPTION
Quick fix for a bad path inside pre_build_hook.
